### PR TITLE
Missing genotype compatible

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 inst/doc
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,5 +8,9 @@ Maintainer: Diptavo Dutta <diptavo@umich.edu>
 Description: Kernel Regression based association tests for Multiple phenotypes. The functions aggregate variant-phenotype score statistic in a particular region and computes corresponding p-values efficiently.
 Depends: SKAT, nlme, copula
 License: GPL (>=2)
-Suggests: knitr,rmarkdown,R.rsp
+Suggests: 
+    knitr,
+    rmarkdown,
+    R.rsp,
+    testthat
 VignetteBuilder: knitr

--- a/MultiSKAT.Rproj
+++ b/MultiSKAT.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/R/Genotype.Kernels.R
+++ b/R/Genotype.Kernels.R
@@ -11,9 +11,9 @@ function(Z,obj.res, kernel = "linear.weighted", Is.Common=FALSE, weights.beta=c(
   if(m < 3 & verbose){
 	msg <-sprintf("Rare variant test with < 3 variants is not advisable")
 	warning(msg,call. = FALSE)}
-  n.rare <- sum(MAF(Z) < 0.01)
+  n.rare <- sum(MAF(Z) < 0.01, na.rm = TRUE)
     if(verbose){print(paste("The region has ",n.rare," rare variants",sep = ""))}
-  mc <- sum(MAC(Z))
+  mc <- sum(MAC(Z), na.rm = TRUE)
   if(mc < 5 & verbose){
 	msg <-sprintf("Rare variant test with total MAC < 5 is not advisable")
 	warning(msg,call. = FALSE)}

--- a/R/Helper.R
+++ b/R/Helper.R
@@ -21,7 +21,7 @@ MAF <- function(G){
 MAC <- function(G){
   mc <- array()
   for(i in 1:ncol(G)){
-    mc[i] <- sum(G[,i] == 1) + 2*min(sum(G[,i] == 2),sum(G[,i] == 0));
+    mc[i] <- sum(G[,i] == 1, na.rm = TRUE) + 2*min(sum(G[,i] == 2, na.rm = TRUE), sum(G[,i] == 0, na.rm = TRUE), na.rm = TRUE);
   }
   return(mc);
 }

--- a/R/Helper.R
+++ b/R/Helper.R
@@ -11,7 +11,7 @@ mat.sqrt <- function(A)
 MAF <- function(G){
   mf <- array()
   for(i in 1:ncol(G)){
-    mf[i] <- sqrt(sum(G[,i] == 0)/nrow(G));
+    mf[i] <- sqrt(sum(G[,i] == 0, na.rm = TRUE)/nrow(G));
     if(mf[i] > 0.5) 
       mf[i] = 1- mf[i];
   }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(MultiSKAT)
+
+test_check("MultiSKAT")

--- a/tests/testthat/test-missing-genotype-data.R
+++ b/tests/testthat/test-missing-genotype-data.R
@@ -1,0 +1,18 @@
+context("test-missing-genotype-data")
+
+
+
+test_that("multiplication works", {
+
+  data(MultiSKAT.example.data)
+  attach(MultiSKAT.example.data)
+  
+  ## Introduce NAs in Genotypes
+  Genotypes[1,1] <- NA
+  
+  expect_warning(MultiSKAT(MultiSKAT_NULL(Phenotypes, Cov), Genotypes, Sigma_p = cov(Phenotypes), verbose = FALSE), 
+                 "The missing genotype rate is 0.000004. Imputation is applied.")
+
+  detach(MultiSKAT.example.data)
+  
+})


### PR DESCRIPTION
Hi @diptavo, 

I have noticed that missing genotype data results in an error in a basic MultiSKAT model. 

``` r
library(MultiSKAT)
#> Loading required package: SKAT
#> Loading required package: nlme
#> Warning: package 'nlme' was built under R version 3.5.2
#> Loading required package: copula
#> Warning: package 'copula' was built under R version 3.5.2
data(MultiSKAT.example.data)
attach(MultiSKAT.example.data)

## Introduce NAs in Genotypes
Genotypes[1,1] <- NA

obj_null <- MultiSKAT_NULL(Phenotypes, Cov)

MultiSKAT(obj_null, Genotypes, Sigma_p = cov(Phenotypes), verbose = FALSE)
#> Error in if (mf[i] > 0.5) mf[i] = 1 - mf[i]: missing value where TRUE/FALSE needed

detach(MultiSKAT.example.data)
```

<sup>Created on 2019-06-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

## Bug fix

I found that the error message stems from the`MAF` function stored in `R/helpers.R`. More specifically, `MAF` contains a `sum` function that will yield in NA, if the G matrix contains any NAs. 
I have added an `na.rm = TRUE` to the sum function. 

I have also added a unit test that will fail with the version you currently have on the master, but pass with my version. 

I let you choose what kind of files you want to merge into your master. 



